### PR TITLE
Update instructions for Gemini setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env.local and insert your API key
+GEMINI_API_KEY=your-gemini-api-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env.local

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.example` to `.env.local` and set the `GEMINI_API_KEY` to your Gemini API key
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- add `.env.example` so users can easily set up their Gemini API key
- ignore `.env.local` and `node_modules`
- update README to mention copying `.env.example`

## Testing
- `git status --short`